### PR TITLE
Altered API for transferable objects.

### DIFF
--- a/example/src/cljs/main/core.cljs
+++ b/example/src/cljs/main/core.cljs
@@ -8,8 +8,11 @@
 (defn print-string-handler [string]
   (println string))
 
-(defn print-array-handler [_ {:keys [array-buffer]}]
-  (println (js/Float32Array. array-buffer)))
+(defn print-array-handler [{:keys [array-buffer]}]
+  (println (-> (.-prototype js/Array)
+               .-slice
+               (.call (js/Float32Array. array-buffer))
+               js->clj)))
 
 ;; Main thread handlers definition.
 (def handlers {:print-string print-string-handler
@@ -25,7 +28,9 @@
 ;; We can use standard clojurescript object as argument.
 (butler/work! example-butler :request-repeat {:repeated "bar" :times 5})
 
-;; To use zero-copy transfering, give a map as fourth argument.
-;; Its vals must be 'Transferable' object.
-(butler/work! example-butler :request-increment nil
-              {:array-buffer (.-buffer (js/Float32Array. #js [1 2 3 4 5 6]))})
+;; To use zero-copy transfering, give sequences of keys as 4th argument.
+(butler/work! example-butler :request-add
+              {:array-buffer (.-buffer (js/Float32Array. #js [1 2 3 4 5 6 7 8]))
+               :nested-map {:nested-buffer (.-buffer (js/Float32Array. #js [1 2 4 8 16 32 64 128]))}}
+              [[:array-buffer] [:nested-map :nested-buffer]])
+

--- a/example/src/cljs/main/core.cljs
+++ b/example/src/cljs/main/core.cljs
@@ -32,5 +32,5 @@
 (butler/work! example-butler :request-add
               {:array-buffer (.-buffer (js/Float32Array. #js [1 2 3 4 5 6 7 8]))
                :nested-map {:nested-buffer (.-buffer (js/Float32Array. #js [1 2 4 8 16 32 64 128]))}}
-              [[:array-buffer] [:nested-map :nested-buffer]])
-
+              [[:array-buffer]
+               [:nested-map :nested-buffer]])

--- a/example/src/cljs/worker/core.cljs
+++ b/example/src/cljs/worker/core.cljs
@@ -10,14 +10,15 @@
 (defn repeat-handler [{:keys [repeated times]}]
   (butler/bring! :print-string (apply str (repeat times repeated))))
 
-(defn increment-handler [_ {:keys [array-buffer]}]
-  (let [arr (js/Float32Array. array-buffer)]
-    (doseq [i (range (.-length arr))]
-      (aset arr i (inc (aget arr i))))
-    (butler/bring! :print-array nil {:array-buffer (.-buffer arr)})))
+(defn add-handler [{:keys [array-buffer nested-map]}]
+  (let [array (js/Float32Array. array-buffer)
+        nested (js/Float32Array. (nested-map :nested-buffer))]
+    (doseq [i (range (.-length array))]
+      (aset array i (+ (aget array i) (aget nested i))))
+    (butler/bring! :print-array {:array-buffer (.-buffer array)} [[:array-buffer]])))
 
 (def handlers {:request-uppercase uppercase-handler
                :request-repeat repeat-handler
-               :request-increment increment-handler})
+               :request-add add-handler})
 
 (butler/serve! handlers)

--- a/src/butler/core.cljs
+++ b/src/butler/core.cljs
@@ -36,7 +36,7 @@
         serialized (serialize {:name name :data without-transferables})
         copying (clj->js {"serialized" serialized
                           "transferables" transferables})]
-    (.postMessage worker copying (clj->js (vals transferables)))))
+    (.postMessage worker copying (clj->js (or (vals transferables) [])))))
 
 (defn butler
   [script handlers]

--- a/src/butler/core.cljs
+++ b/src/butler/core.cljs
@@ -22,10 +22,10 @@
   (into {} (for [[k v] m] [(f k) v])))
 
 (defn- message-handler [handlers e]
-  (let [deserialized (deserialize (.-serialized (.-data e)))
+  (let [deserialized (deserialize (aget (.-data e) "serialized"))
         name (keyword (:name deserialized))
         data (:data deserialized)
-        transferables (map-key deserialize (js->clj (.-transferables (.-data e))))
+        transferables (map-key deserialize (js->clj (aget (.-data e) "transferables")))
         copied (reduce #(assoc-in %1 (first %2) (second %2)) data transferables)]
     (when-let [handler (get handlers name)]
       (handler copied))))

--- a/src/butler/core.cljs
+++ b/src/butler/core.cljs
@@ -22,19 +22,21 @@
   (into {} (for [[k v] m] [(f k) v])))
 
 (defn- message-handler [handlers e]
-  (let [o (deserialize (.-serialized (.-data e)))
-        transferables (map-key deserialize (js->clj (.-transferables (.-data e))))]
-    (when-let [handler (get handlers (keyword (:name o)) nil)]
-      (if (< 0 (count transferables))
-        (handler (:data o) transferables)
-        (handler (:data o))))))
+  (let [deserialized (deserialize (.-serialized (.-data e)))
+        name (keyword (:name deserialized))
+        data (:data deserialized)
+        transferables (map-key deserialize (js->clj (.-transferables (.-data e))))
+        copied (reduce #(assoc-in %1 (first %2) (second %2)) data transferables)]
+    (when-let [handler (get handlers name)]
+      (handler copied))))
 
-(defn- post-message! [worker name copying-data transferable-map]
-  (let [serialized-data (serialize {:name name :data copying-data})
-        serialized-map (map-key serialize transferable-map)
-        copying (clj->js {"serialized" serialized-data
-                          "transferables" serialized-map})]
-    (.postMessage worker copying (clj->js (vals transferable-map)))))
+(defn- post-message! [worker name copying-data transferable-keys]
+  (let [without-transferables (reduce #(assoc-in %1 %2 nil) copying-data transferable-keys)
+        transferables (into {} (map (fn [key] [(serialize key) (get-in copying-data key)]) transferable-keys))
+        serialized (serialize {:name name :data without-transferables})
+        copying (clj->js {"serialized" serialized
+                          "transferables" transferables})]
+    (.postMessage worker copying (clj->js (vals transferables)))))
 
 (defn butler
   [script handlers]
@@ -45,8 +47,8 @@
 ;; for owner
 
 (defn work!
-  ([b name copying-data transferable-map]
-   (post-message! (:worker b) name copying-data transferable-map))
+  ([b name copying-data transferable-keys]
+   (post-message! (:worker b) name copying-data transferable-keys))
   ([b name copying-data]
    (work! b name copying-data {}))
   ([b name]
@@ -59,8 +61,10 @@
   (.addEventListener js/self event-message (partial message-handler handlers)))
 
 (defn bring!
-  ([name copying-data transferable-map]
-   (post-message! js/self name copying-data transferable-map))
+  ([name copying-data transferable-keys]
+   (post-message! js/self name copying-data transferable-keys))
   ([name copying-data]
-   (bring! name copying-data {})))
+   (bring! name copying-data {}))
+  ([name]
+   (bring! name nil)))
 

--- a/src/butler/core.cljs
+++ b/src/butler/core.cljs
@@ -50,7 +50,7 @@
   ([b name copying-data transferable-keys]
    (post-message! (:worker b) name copying-data transferable-keys))
   ([b name copying-data]
-   (work! b name copying-data {}))
+   (work! b name copying-data []))
   ([b name]
    (work! b name nil)))
 
@@ -64,7 +64,6 @@
   ([name copying-data transferable-keys]
    (post-message! js/self name copying-data transferable-keys))
   ([name copying-data]
-   (bring! name copying-data {}))
+   (bring! name copying-data []))
   ([name]
    (bring! name nil)))
-


### PR DESCRIPTION
Changed `work!` and `bring!` to specify keys of transferable objects in the style of 'get-in'.
